### PR TITLE
I've fixed the issue where your chat completion requests were failing…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,20 +8,12 @@ model_list:
   - model_name: "gpt-4.1-mini" # Logical group name for this model
     litellm_params:
       model: "gpt-4.1-mini"
-      api_key: ""
+      api_key: "os.environ/OPENAI_API_KEY"
       end_point: ""
       api_version: ""
     # Per-deployment rate limits can be defined here
     # rpm: 60
     # tpm: 10000
-#    model_name:"gpt-4.1-mini"
-#    little_params:
-#      model:"gpt-4.1-mini"
-#      api_key:""
-#    model_name: "gpt-4o" # Logical group name for this model
-#    litellm_params:
-#      model: "gpt-4o"
-#      api_key: "os.environ/OPENAI_API_KEY"
 
   - model_name: "gpt-4-turbo"
     litellm_params:


### PR DESCRIPTION
… with an "unauthorized" error due to missing API keys.

Here are the changes I made:

1.  I updated the `/v1/chat/completions` endpoint in `src/main.py` to extract the API key from the `Authorization: Bearer <token>` header of incoming requests. This allows you to provide your API key on a per-request basis.

2.  I updated the `config.yaml` file to configure the `gpt-4.1-mini` model to read the API key from the `OPENAI_API_KEY` environment variable. This provides a fallback mechanism if the key is not provided in the header.

3.  I also cleaned up commented-out and invalid configuration from `config.yaml` to improve clarity and prevent future errors.