### PR TITLE
refactor: Clean up ChatCompletionRequest schema

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -24,8 +24,6 @@ class ChatCompletionRequest(BaseModel):
     frequency_penalty: Optional[float] = None
     logit_bias: Optional[Dict[str, float]] = None
     user: Optional[str] = None
-    endpoint: Optional[str] = None
-    api_version: Optional[str] = None
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
This commit removes the `endpoint` and `api_version` fields from the `ChatCompletionRequest` Pydantic model.

These fields were causing confusion for users, as they appeared in the API documentation while the primary method for configuring them (especially for Azure OpenAI) is via the `config.yaml` file.

By removing these fields from the request body, we make the API cleaner and reinforce that provider-specific credentials like `endpoint` and `api_version` should be managed centrally in the configuration file.