### PR TITLE
feat: Add boto3 dependency for AWS Bedrock support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]
 litellm
 PyYAML
 python-dotenv
+boto3


### PR DESCRIPTION
This commit adds the `boto3` library to the project's dependencies.

The `boto3` library is the AWS SDK for Python and is required by `litellm` to connect to Amazon Bedrock models. This dependency was previously missing, causing an `ImportError` when attempting to make a request to a Bedrock model.