### PR TITLE
feat: Add in-memory caching mechanism

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -52,6 +52,12 @@ litellm_settings:
   # Enables verbose logging from the litellm library for debugging.
   set_verbose: true
 
+  # Enables in-memory caching for responses.
+  cache: true
+  cache_params:
+    type: "local"  # Use the simple in-memory cache.
+    ttl: 600       # Cache responses for 10 minutes.
+
   # Global list of models to use as a last resort if a specific model group's fallbacks fail.
   # default_fallbacks: ["gpt-4o"]
 


### PR DESCRIPTION
This change enables an in-memory caching mechanism for the LiteLLM proxy by modifying the `config.yaml`.

It sets the cache type to 'local' and configures a time-to-live (TTL) of 600 seconds for cached entries. This will improve performance and reduce costs for repeated requests.